### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ jobs:
     - name: Publish to GitHub Packages
       uses: inforlife/publish-docker-image-to-github-packages-action@v3
       with:
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ secrets.INFORLIFE_ACCESS_TOKEN }}
         slack_token: ${{ secrets.SLACK_TOKEN }}
 ```
 
 ## Secrets
-**The `SLACK_TOKEN` must be added to the Repo's secrets via GitHub UI.**
+- **The `INFORLIFE_ACCESS_TOKEN` must be created and added to the Repo's secrets via GitHub UI.** The token should be unique for the repo and have `read:packages, repo, write:packages` permissions.
+- **The `SLACK_TOKEN` must be added to the Repo's secrets via GitHub UI.**
 
 ## Docker image
 This action creates the package `docker.pkg.github.com/inforlife/registry/<REPO>:<RELEASE_TAG>`.


### PR DESCRIPTION
Now that we push the Docker Images to a shared repo (and we don't store them within the repo itself) we need the `GITHUB_TOKEN` can't be used anymore for authentication.
A dedicated secret (`INFORLIFE_ACCESS_TOKEN`) with the right permissions needs to be defined.