### PR TITLE
Pass the release tag to Docker 

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -12,13 +12,13 @@ if [ -z "${INPUT_SLACK_TOKEN}" ]; then
   exit 1
 fi
 
-DOCKERTAG=${GITHUB_REF:10}
+RELEASE_TAG=${GITHUB_REF:10}
 REPO=$(echo ${GITHUB_REPOSITORY} | cut -d'/' -f2-)
 
+docker build --build-arg RELEASE_TAG=${RELEASE_TAG} -t image .
 echo ${INPUT_PASSWORD} | docker login docker.pkg.github.com -u inforlife --password-stdin
-docker build -t ${DOCKERTAG} .
-docker tag ${DOCKERTAG} docker.pkg.github.com/inforlife/registry/${REPO}:${DOCKERTAG}
-docker push docker.pkg.github.com/inforlife/registry/${REPO}:${DOCKERTAG}
+docker tag image docker.pkg.github.com/inforlife/registry/${REPO}:${RELEASE_TAG}
+docker push docker.pkg.github.com/inforlife/registry/${REPO}:${RELEASE_TAG}
 docker logout
 
-curl -X POST -H 'Content-type: application/json' --data '{"text":"The image '${REPO}':'${DOCKERTAG}' has been published to the InfoRLife registry."}' https://hooks.slack.com/services/${INPUT_SLACK_TOKEN}
+curl -X POST -H 'Content-type: application/json' --data '{"text":"The image '${REPO}':'${RELEASE_TAG}' has been published to the InfoRLife registry."}' https://hooks.slack.com/services/${INPUT_SLACK_TOKEN}


### PR DESCRIPTION
Once merged, the `v4` release needs to be drafted since `TrainingHub` expects it.